### PR TITLE
Updated image to 1-1-bullseye

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Rust",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
 	"customizations": {
 		"vscode": {
 			"extensions": [


### PR DESCRIPTION
- The current 0-1-bullseye image have a very old version of rustc as well as not working well as a dev-container. Upgrading to 1-1-solves all these problems.